### PR TITLE
feat: themed search box border for all its states

### DIFF
--- a/lib/src/autocomplete_search.dart
+++ b/lib/src/autocomplete_search.dart
@@ -126,6 +126,11 @@ class AutoCompleteSearchState extends State<AutoCompleteSearch> {
       decoration: InputDecoration(
         hintText: widget.hintText,
         border: InputBorder.none,
+        errorBorder: InputBorder.none,
+        enabledBorder: InputBorder.none,
+        focusedBorder: InputBorder.none,
+        disabledBorder: InputBorder.none,
+        focusedErrorBorder: InputBorder.none,
         isDense: true,
         contentPadding: widget.contentPadding,
       ),


### PR DESCRIPTION
Ony 'border' was defined as none. So, if the APP Theme set other type of border on any other state (enable, focused, disabled, etc) it could affect the search field.

Changes to be committed:
	modified:   lib/src/autocomplete_search.dart